### PR TITLE
#7: Remove commons-lang3 dependency

### DIFF
--- a/change-proneness-ranker/pom.xml
+++ b/change-proneness-ranker/pom.xml
@@ -27,11 +27,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.hjug.refactorfirst.testresources</groupId>
             <artifactId>test-resources</artifactId>
         </dependency>

--- a/change-proneness-ranker/src/main/java/org/hjug/git/GitLogReader.java
+++ b/change-proneness-ranker/src/main/java/org/hjug/git/GitLogReader.java
@@ -30,7 +30,7 @@ public class GitLogReader implements RepositoryLogReader {
         FileRepositoryBuilder repositoryBuilder =
                 new FileRepositoryBuilder().findGitDir(basedir);
         String gitIndexFileEnvVariable = System.getenv("GIT_INDEX_FILE");
-        if (Objects.nonNull(gitIndexFileEnvVariable) && !gitIndexFileEnvVariable.isEmpty()) {
+        if (Objects.nonNull(gitIndexFileEnvVariable) && !gitIndexFileEnvVariable.trim().isEmpty()) {
             log.debug("Setting Index File based on Env Variable GIT_INDEX_FILE {}", gitIndexFileEnvVariable);
             repositoryBuilder = repositoryBuilder.setIndexFile(new File(gitIndexFileEnvVariable));
         }

--- a/change-proneness-ranker/src/main/java/org/hjug/git/GitLogReader.java
+++ b/change-proneness-ranker/src/main/java/org/hjug/git/GitLogReader.java
@@ -1,7 +1,6 @@
 package org.hjug.git;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.DiffEntry;
@@ -31,7 +30,7 @@ public class GitLogReader implements RepositoryLogReader {
         FileRepositoryBuilder repositoryBuilder =
                 new FileRepositoryBuilder().findGitDir(basedir);
         String gitIndexFileEnvVariable = System.getenv("GIT_INDEX_FILE");
-        if (StringUtils.isNotBlank(gitIndexFileEnvVariable)) {
+        if (Objects.nonNull(gitIndexFileEnvVariable) && !gitIndexFileEnvVariable.isEmpty()) {
             log.debug("Setting Index File based on Env Variable GIT_INDEX_FILE {}", gitIndexFileEnvVariable);
             repositoryBuilder = repositoryBuilder.setIndexFile(new File(gitIndexFileEnvVariable));
         }

--- a/pom.xml
+++ b/pom.xml
@@ -120,13 +120,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.4</version>
-                <scope>compile</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>net.sourceforge.pmd</groupId>
                 <artifactId>pmd-java</artifactId>
                 <!--works - stops working with 6.0.0-->


### PR DESCRIPTION
Hello! It's me again!

As per Issue #7, removed all occurrences of `commons-lang3` dependency coming from `org.apache.commons`.

I saw it was used only at `GitLogReader` for an `isNotBlank()` operation

According to its [documentation](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringUtils.html#isNotBlank-java.lang.CharSequence-), it checks for 3 things

1. String is not empty `("")`
2. String is not null
3. String is not just whitespaces alone `("      ")`

To get the same behavior, I replaced the `isNotBlank()` with 
- `Objects.nonNull()` to handle 2
- `!isEmpty()` from `String` class to handle 1
- `trim()` before the `!isEmpty()` check to handle 3

Feel free to let me know if you had something else in mind for #7!