### PR TITLE
Parse using locale to match AbstractRuleViolationFactory formatting

### DIFF
--- a/effort-ranker/src/main/java/org/hjug/metrics/GodClass.java
+++ b/effort-ranker/src/main/java/org/hjug/metrics/GodClass.java
@@ -2,6 +2,9 @@ package org.hjug.metrics;
 
 import lombok.Data;
 
+import java.text.NumberFormat;
+import java.text.ParseException;
+
 /**
  * Created by Jim on 11/16/2016.
  */
@@ -24,11 +27,20 @@ public class GodClass {
         this.fileName = fileName;
         this.packageName = packageName;
 
-        //null (WMC=79, ATFD=79, TCC=0.027777777777777776)
+        NumberFormat integerFormat = NumberFormat.getIntegerInstance();
+
         String [] values = result.substring(result.indexOf("(") + 1, result.indexOf(")")).split(", ");
-        wmc = Integer.valueOf(values[0].split("=")[1]);
-        atfd = Integer.valueOf(values[1].split("=")[1]);
-        String rawTcc = values[2].split("=")[1];
+        try {
+            wmc = (int) (long) integerFormat.parse(extractValue(values[0]));
+            atfd = (int) (long)  integerFormat.parse(extractValue(values[1]));
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+        String rawTcc = extractValue(values[2]);
         tcc = Float.valueOf(rawTcc.replace("%", ""));
+    }
+
+    private String extractValue(String value) {
+        return value.split("=")[1];
     }
 }

--- a/effort-ranker/src/test/java/org/hjug/metrics/GodClassParsingTest.java
+++ b/effort-ranker/src/test/java/org/hjug/metrics/GodClassParsingTest.java
@@ -1,0 +1,35 @@
+package org.hjug.metrics;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+public class GodClassParsingTest {
+
+    private Locale defaultLocale;
+
+    @Before
+    public void before() {
+        defaultLocale = Locale.getDefault(Locale.Category.FORMAT);
+        Locale.setDefault(Locale.Category.FORMAT, Locale.ENGLISH);
+    }
+
+    @After
+    public void after() {
+        Locale.setDefault(defaultLocale);
+    }
+
+    @Test
+    public void test() {
+        String result = "Possible God Class (WMC=9200, ATFD=1,700, TCC=4.597%)";
+        GodClass god = new GodClass("a.txt", "org.hjug", result);
+        assertEquals(Integer.valueOf(9200), god.getWmc());
+        assertEquals(Integer.valueOf(1700), god.getAtfd());
+        assertEquals(Float.valueOf(4.597f), god.getTcc());
+    }
+
+}


### PR DESCRIPTION
AbstractRuleViolationFactory is using MessageFormat with the current locale to format. GodClass should do the same thing to parse.