### PR TITLE
Add non-root-POM feature to Maven plugin

### DIFF
--- a/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstJsonReport/RefactorFirstMavenJsonReport.java
+++ b/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstJsonReport/RefactorFirstMavenJsonReport.java
@@ -4,6 +4,8 @@ import static org.hjug.mavenreport.ReportWriter.writeReportToDisk;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -36,7 +38,14 @@ public class RefactorFirstMavenJsonReport extends AbstractMojo {
 
     @Override
     public void execute() {
-        final String projectBaseDir = project.getBasedir().getPath();
+        String projectBaseDir;
+
+        File baseDir = project.getBasedir();
+        if (baseDir != null) {
+            projectBaseDir = baseDir.getPath();
+        } else {
+            projectBaseDir = Paths.get("").toAbsolutePath().toString();
+        }
 
         final CostBenefitCalculator costBenefitCalculator = new CostBenefitCalculator();
         final List<RankedDisharmony> rankedDisharmonies =

--- a/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstMavenCsvReport.java
+++ b/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstMavenCsvReport.java
@@ -94,7 +94,6 @@ public class RefactorFirstMavenCsvReport extends AbstractMojo {
             projectBaseDir = baseDir.getPath();
             optionalGitDir = Optional.ofNullable(gitLogReader.getGitDir(baseDir));
         } else {
-            // TODO: ensure File is initialized to the project root directory, not PWD
             projectBaseDir = Paths.get("").toAbsolutePath().toString();
             optionalGitDir = Optional.ofNullable(gitLogReader.getGitDir(new File(projectBaseDir)));
         }

--- a/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/ReportWriter.java
+++ b/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/ReportWriter.java
@@ -12,7 +12,10 @@ import org.apache.maven.project.MavenProject;
 public class ReportWriter {
     public static void writeReportToDisk(
             final MavenProject project, final String filename, final StringBuilder stringBuilder) {
-        final String reportOutputDirectory = project.getModel().getReporting().getOutputDirectory();
+        final String reportOutputDirectory = project.getModel()
+                .getReporting()
+                .getOutputDirectory()
+                .replace("${project.basedir}" + File.separator, "");
         final File reportOutputDir = new File(reportOutputDirectory);
 
         if (!reportOutputDir.exists()) {


### PR DESCRIPTION
Introduces ability to the Maven plugin to work with projects which lack a root-level POM file. Changes to specific classes are as follows:

RefactorFirstMavenReport
- Set requiresProject parameter to false. A true value will result in MissingProjectException being thrown if no root-level POM file is present. A falsy value is required to enable scanning of projects without a root-level POM file.
- Added check (starting line 133) for default project name & substitution. The MavenProject dependency will use a default project name of "Maven Sub Project (No POM)" if a root-level POM file is not present. If that name is detected, replace it with the name of the project's root directory.
- Added handling (starting line 202) for an upstream bug in MavenProject dependency. This class's getBasedir method returns null instead of a File instance if no POM file is present in the proejct's root dir. This, in turn, was causing a chained getPath call to fail. Added a check to see if a getBasedir call returns null, and set projectBasedir conditionally.

RefactorFirstMavenCsvReport
- Set requiresProject parameter to false.
- Added check (starting line 79) for default project name & substitutio.
- Added handling (starting line 89) for an upstream bug in MavenProject dependency.

ReportWriter
- In the absence of a root-level POM file, the MavenProject class was returning "${project.basedir}/target/site" as the output directory. Added call to replace to scrub the output directory of the default.

RefactorFirstMavenJsonReport
- Added handling (starting line 41) for an upstream bug in MavenProject dependency.


Tested these changes in the following scenarios, all of which produce expected/correct behaviour:
- projects containing a root-level POM file
- projects lacking any POM files
- projects without a root-level POM, but containing sub-projects which DO have their own POM files