### PR TITLE
RefactorFirstMavenJsonReport config update

### DIFF
--- a/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstJsonReport/RefactorFirstMavenJsonReport.java
+++ b/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstJsonReport/RefactorFirstMavenJsonReport.java
@@ -25,7 +25,7 @@ import org.hjug.cbc.RankedDisharmony;
         name = "jsonreport",
         defaultPhase = LifecyclePhase.SITE,
         requiresDependencyResolution = ResolutionScope.RUNTIME,
-        requiresProject = true,
+        requiresProject = false,
         threadSafe = true,
         inheritByDefault = false)
 public class RefactorFirstMavenJsonReport extends AbstractMojo {


### PR DESCRIPTION
One line change to set requiresProject parameter of RefactorFirstMavenJsonReport to false. Ensures JSON format behaves correctly with projects not using a root-level POM file.