### PR TITLE
Add true class name

### DIFF
--- a/cost-benefit-calculator/src/main/java/org/hjug/cbc/RankedDisharmony.java
+++ b/cost-benefit-calculator/src/main/java/org/hjug/cbc/RankedDisharmony.java
@@ -10,6 +10,7 @@ import org.hjug.metrics.GodClass;
 public class RankedDisharmony {
 
     private final String path;
+    private final String fileName;
     private final String className;
     private final Integer effortRank;
     private final Integer changePronenessRank;
@@ -29,7 +30,8 @@ public class RankedDisharmony {
     public RankedDisharmony(GodClass godClass, ScmLogInfo scmLogInfo) {
         path = scmLogInfo.getPath();
         // from https://stackoverflow.com/questions/1011287/get-file-name-from-a-file-location-in-java
-        className = Paths.get(path).getFileName().toString();
+        fileName = Paths.get(path).getFileName().toString();
+        className = godClass.getClassName();
         changePronenessRank = scmLogInfo.getChangePronenessRank();
         effortRank = godClass.getOverallRank();
         priority = changePronenessRank - effortRank;

--- a/effort-ranker/src/main/java/org/hjug/metrics/GodClass.java
+++ b/effort-ranker/src/main/java/org/hjug/metrics/GodClass.java
@@ -10,6 +10,7 @@ import lombok.Data;
 @Data
 public class GodClass {
 
+    private String className;
     private String fileName;
     private String packageName;
     private Integer wmc;
@@ -22,7 +23,8 @@ public class GodClass {
     private Integer sumOfRanks;
     private Integer overallRank;
 
-    public GodClass(String fileName, String packageName, String result) {
+    public GodClass(String className, String fileName, String packageName, String result) {
+        this.className = className;
         this.fileName = fileName;
         this.packageName = packageName;
 

--- a/effort-ranker/src/main/java/org/hjug/metrics/PMDGodClassRuleRunner.java
+++ b/effort-ranker/src/main/java/org/hjug/metrics/PMDGodClassRuleRunner.java
@@ -73,7 +73,11 @@ public class PMDGodClassRuleRunner {
             // write results
             if (!ctx.getReport().isEmpty()) {
                 for (final RuleViolation violation : ctx.getReport()) {
-                    godClass = new GodClass(sourceCodeFileName, violation.getPackageName(), violation.getDescription());
+                    godClass = new GodClass(
+                            violation.getClassName(),
+                            sourceCodeFileName,
+                            violation.getPackageName(),
+                            violation.getDescription());
                 }
             }
         } catch (PMDException ignore) {

--- a/effort-ranker/src/test/java/org/hjug/metrics/GodClassParsingTest.java
+++ b/effort-ranker/src/test/java/org/hjug/metrics/GodClassParsingTest.java
@@ -25,7 +25,7 @@ public class GodClassParsingTest {
     @Test
     public void test() {
         String result = "Possible God Class (WMC=9200, ATFD=1,700, TCC=4.597%)";
-        GodClass god = new GodClass("a.txt", "org.hjug", result);
+        GodClass god = new GodClass("a", "a.txt", "org.hjug", result);
         assertEquals(Integer.valueOf(9200), god.getWmc());
         assertEquals(Integer.valueOf(1700), god.getAtfd());
         assertEquals(Float.valueOf(4.597f), god.getTcc());

--- a/effort-ranker/src/test/java/org/hjug/metrics/GodClassRankerTest.java
+++ b/effort-ranker/src/test/java/org/hjug/metrics/GodClassRankerTest.java
@@ -14,22 +14,26 @@ public class GodClassRankerTest {
     private final GodClassRanker godClassRanker = new GodClassRanker();
 
     private final GodClass attributeHandler = new GodClass(
+            "AttributeHandler",
             "org/hjug/git/AttributeHandler.java",
             "org.apache.myfaces.tobago.facelets",
             "null (WMC=79, ATFD=79, TCC=0.027777777777777776)");
     private final GodClass attributeHandler2 = new GodClass(
+            "AttributeHandler",
             "org/hjug/git/AttributeHandler.java",
             "org.apache.myfaces.tobago.facelets",
             "null (WMC=79, ATFD=79, TCC=0.027777777777777776)");
-    private final GodClass sorter =
-            new GodClass("Sorter.java", "org.apache.myfaces.tobago.facelets", " God class (WMC=51, ATFD=25, TCC=0.2)");
-    private final GodClass sorter2 =
-            new GodClass("Sorter2.java", "org.apache.myfaces.tobago.facelets", " God class (WMC=51, ATFD=25, TCC=0.2)");
+    private final GodClass sorter = new GodClass(
+            "Sorter", "Sorter.java", "org.apache.myfaces.tobago.facelets", " God class (WMC=51, ATFD=25, TCC=0.2)");
+    private final GodClass sorter2 = new GodClass(
+            "Sorter", "Sorter2.java", "org.apache.myfaces.tobago.facelets", " God class (WMC=51, ATFD=25, TCC=0.2)");
     private final GodClass themeImpl = new GodClass(
+            "ThemeImpl",
             "ThemeImpl.java",
             "org.apache.myfaces.tobago.facelets",
             "God class (WMC=60, ATFD=16, TCC=0.07816091954022988)");
     private final GodClass themeImpl2 = new GodClass(
+            "ThemeImpl",
             "ThemeImpl2.java",
             "org.apache.myfaces.tobago.facelets",
             "God class (WMC=60, ATFD=16, TCC=0.07816091954022988)");

--- a/graph-data-generator/src/main/java/org/hjug/gdg/GraphDataGenerator.java
+++ b/graph-data-generator/src/main/java/org/hjug/gdg/GraphDataGenerator.java
@@ -41,7 +41,7 @@ public class GraphDataGenerator {
             RankedDisharmony rankedDisharmony = rankedDisharmonies.get(i);
             chartData.append("[");
             chartData.append("'");
-            chartData.append(rankedDisharmony.getClassName());
+            chartData.append(rankedDisharmony.getFileName());
             chartData.append("',");
             chartData.append(rankedDisharmony.getEffortRank());
             chartData.append(",");

--- a/graph-data-generator/src/test/java/org/hjug/gdg/GraphDataGeneratorTest.java
+++ b/graph-data-generator/src/test/java/org/hjug/gdg/GraphDataGeneratorTest.java
@@ -55,6 +55,7 @@ public class GraphDataGeneratorTest {
     @Test
     public void generateBubbleChartDataOneDataPoint() {
         GodClass godClass = new GodClass(
+                "AttributeHandler",
                 "AttributeHandler.java",
                 "org.apache.myfaces.tobago.facelets",
                 "(WMC=77, ATFD=105, TCC=15.555999755859375)");
@@ -76,6 +77,7 @@ public class GraphDataGeneratorTest {
     @Test
     public void generateBubbleChartDataTwoDataPoints() {
         GodClass godClass = new GodClass(
+                "AttributeHandler",
                 "AttributeHandler.java",
                 "org.apache.myfaces.tobago.facelets",
                 "(WMC=77, ATFD=105, TCC=15.555999755859375)");

--- a/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstJsonReport/JsonReportDisharmonyEntry.java
+++ b/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstJsonReport/JsonReportDisharmonyEntry.java
@@ -15,7 +15,11 @@ class JsonReportDisharmonyEntry {
             .withLocale(Locale.getDefault())
             .withZone(ZoneId.systemDefault());
 
+    private final String fileName;
+
     private final String className;
+
+    private final String fullFilePath;
 
     private final Integer effortRank;
 
@@ -29,10 +33,9 @@ class JsonReportDisharmonyEntry {
 
     private final String mostRecentCommitTime;
 
-    private final String fullPath;
-
     public static JsonReportDisharmonyEntry fromRankedDisharmony(RankedDisharmony entry) {
         return JsonReportDisharmonyEntry.builder()
+                .fileName(entry.getFileName())
                 .className(entry.getClassName())
                 .effortRank(entry.getEffortRank())
                 .changePronenessRank(entry.getChangePronenessRank())
@@ -40,7 +43,7 @@ class JsonReportDisharmonyEntry {
                 .weightedMethodCount(entry.getWmc())
                 .commitCount(entry.getCommitCount())
                 .mostRecentCommitTime(formatter.format(entry.getMostRecentCommitTime()))
-                .fullPath(entry.getPath())
+                .fullFilePath(entry.getPath())
                 .build();
     }
 }

--- a/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstJsonReport/JsonReportDisharmonyEntry.java
+++ b/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstJsonReport/JsonReportDisharmonyEntry.java
@@ -29,6 +29,8 @@ class JsonReportDisharmonyEntry {
 
     private final String mostRecentCommitTime;
 
+    private final String fullPath;
+
     public static JsonReportDisharmonyEntry fromRankedDisharmony(RankedDisharmony entry) {
         return JsonReportDisharmonyEntry.builder()
                 .className(entry.getClassName())
@@ -38,6 +40,7 @@ class JsonReportDisharmonyEntry {
                 .weightedMethodCount(entry.getWmc())
                 .commitCount(entry.getCommitCount())
                 .mostRecentCommitTime(formatter.format(entry.getMostRecentCommitTime()))
+                .fullPath(entry.getPath())
                 .build();
     }
 }

--- a/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstMavenCsvReport.java
+++ b/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstMavenCsvReport.java
@@ -180,7 +180,7 @@ public class RefactorFirstMavenCsvReport extends AbstractMojo {
 
     private String[] getDataList(RankedDisharmony rankedDisharmony) {
         String[] simpleRankedDisharmonyData = {
-            rankedDisharmony.getClassName(),
+            rankedDisharmony.getFileName(),
             rankedDisharmony.getPriority().toString(),
             rankedDisharmony.getChangePronenessRank().toString(),
             rankedDisharmony.getEffortRank().toString(),
@@ -190,7 +190,7 @@ public class RefactorFirstMavenCsvReport extends AbstractMojo {
         };
 
         String[] detailedRankedDisharmonyData = {
-            rankedDisharmony.getClassName(),
+            rankedDisharmony.getFileName(),
             rankedDisharmony.getPriority().toString(),
             rankedDisharmony.getChangePronenessRank().toString(),
             rankedDisharmony.getEffortRank().toString(),

--- a/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstMavenReport.java
+++ b/refactor-first-maven-plugin/src/main/java/org/hjug/mavenreport/RefactorFirstMavenReport.java
@@ -278,7 +278,7 @@ public class RefactorFirstMavenReport extends AbstractMojo {
             stringBuilder.append("<tr>");
 
             String[] simpleRankedDisharmonyData = {
-                rankedDisharmony.getClassName(),
+                rankedDisharmony.getFileName(),
                 rankedDisharmony.getPriority().toString(),
                 rankedDisharmony.getChangePronenessRank().toString(),
                 rankedDisharmony.getEffortRank().toString(),
@@ -288,7 +288,7 @@ public class RefactorFirstMavenReport extends AbstractMojo {
             };
 
             String[] detailedRankedDisharmonyData = {
-                rankedDisharmony.getClassName(),
+                rankedDisharmony.getFileName(),
                 rankedDisharmony.getPriority().toString(),
                 rankedDisharmony.getChangePronenessRank().toString(),
                 rankedDisharmony.getEffortRank().toString(),


### PR DESCRIPTION
Class name and file name were being conflated. In most cases the two are
the same but not always.

I renamed the existing className property in RankedDisharmony to
fileName to reflect what it actually is.

I added a new className property which is set to the actual
className.

To get class name passed into the logic where RankedDisharmony is
constructed I also had to update the GodClass definition to include
className as well as file name.

The HTML and CVS report output should not change. I updated them to
call getFileName from ranked disharmony rather than getClassName. This
preserves existing behavior.

The only output which should change is the  JSON report which will now expose both fileName and className, letting the
consumer choose which they care about.
