### PR TITLE
Sort pom files

### DIFF
--- a/change-proneness-ranker/pom.xml
+++ b/change-proneness-ranker/pom.xml
@@ -1,37 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>org.hjug.refactorfirst</groupId>
-        <artifactId>refactor-first</artifactId>
-        <version>0.3.1-SNAPSHOT</version>
-    </parent>
-
-    <groupId>org.hjug.refactorfirst.changepronenessranker</groupId>
-    <artifactId>change-proneness-ranker</artifactId>
-
-    <build>
-        <testResources>
-            <testResource>
-                <directory>${project.basedir}/src/test/resources</directory>
-            </testResource>
-        </testResources>
-    </build>
-
-    <dependencies>
-
-        <dependency>
-            <groupId>org.eclipse.jgit</groupId>
-            <artifactId>org.eclipse.jgit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hjug.refactorfirst.testresources</groupId>
-            <artifactId>test-resources</artifactId>
-        </dependency>
-
-
-    </dependencies>
-
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.hjug.refactorfirst</groupId>
+    <artifactId>refactor-first</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+  </parent>
+  <groupId>org.hjug.refactorfirst.changepronenessranker</groupId>
+  <artifactId>change-proneness-ranker</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.testresources</groupId>
+      <artifactId>test-resources</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <testResources>
+      <testResource>
+        <directory>${project.basedir}/src/test/resources</directory>
+      </testResource>
+    </testResources>
+  </build>
 </project>

--- a/cost-benefit-calculator/pom.xml
+++ b/cost-benefit-calculator/pom.xml
@@ -1,32 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>org.hjug.refactorfirst</groupId>
-        <artifactId>refactor-first</artifactId>
-        <version>0.3.1-SNAPSHOT</version>
-    </parent>
-
-    <groupId>org.hjug.refactorfirst.costbenefitcalculator</groupId>
-    <artifactId>cost-benefit-calculator</artifactId>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.hjug.refactorfirst.changepronenessranker</groupId>
-            <artifactId>change-proneness-ranker</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hjug.refactorfirst.effortranker</groupId>
-            <artifactId>effort-ranker</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hjug.refactorfirst.testresources</groupId>
-            <artifactId>test-resources</artifactId>
-        </dependency>
-
-    </dependencies>
-
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.hjug.refactorfirst</groupId>
+    <artifactId>refactor-first</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+  </parent>
+  <groupId>org.hjug.refactorfirst.costbenefitcalculator</groupId>
+  <artifactId>cost-benefit-calculator</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.changepronenessranker</groupId>
+      <artifactId>change-proneness-ranker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.effortranker</groupId>
+      <artifactId>effort-ranker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.testresources</groupId>
+      <artifactId>test-resources</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -1,66 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
-    <!-- From https://cylab.be/blog/97/compute-code-coverage-for-a-multi-module-maven-project-with-jacoco -->
-
-    <parent>
-        <groupId>org.hjug.refactorfirst</groupId>
-        <artifactId>refactor-first</artifactId>
-        <version>0.3.1-SNAPSHOT</version>
-    </parent>
-
-    <artifactId>coverage</artifactId>
-
-    <description>Compute aggregated test code coverage</description>
-
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.hjug.refactorfirst.changepronenessranker</groupId>
-            <artifactId>change-proneness-ranker</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hjug.refactorfirst.effortranker</groupId>
-            <artifactId>effort-ranker</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hjug.refactorfirst.costbenefitcalculator</groupId>
-            <artifactId>cost-benefit-calculator</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hjug.refactorfirst.graphdatagenerator</groupId>
-            <artifactId>graph-data-generator</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hjug.refactorfirst.plugin</groupId>
-            <artifactId>refactor-first-maven-plugin</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.6</version>
-                <executions>
-                    <execution>
-                        <id>report-aggregate</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>report-aggregate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+  <modelVersion>4.0.0</modelVersion>
+  <!-- From https://cylab.be/blog/97/compute-code-coverage-for-a-multi-module-maven-project-with-jacoco -->
+  <parent>
+    <groupId>org.hjug.refactorfirst</groupId>
+    <artifactId>refactor-first</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>coverage</artifactId>
+  <description>Compute aggregated test code coverage</description>
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.changepronenessranker</groupId>
+      <artifactId>change-proneness-ranker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.costbenefitcalculator</groupId>
+      <artifactId>cost-benefit-calculator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.effortranker</groupId>
+      <artifactId>effort-ranker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.graphdatagenerator</groupId>
+      <artifactId>graph-data-generator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.plugin</groupId>
+      <artifactId>refactor-first-maven-plugin</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.6</version>
+        <executions>
+          <execution>
+            <id>report-aggregate</id>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/effort-ranker/pom.xml
+++ b/effort-ranker/pom.xml
@@ -1,36 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>org.hjug.refactorfirst</groupId>
-        <artifactId>refactor-first</artifactId>
-        <version>0.3.1-SNAPSHOT</version>
-    </parent>
-
-    <groupId>org.hjug.refactorfirst.effortranker</groupId>
-    <artifactId>effort-ranker</artifactId>
-
-    <dependencies>
-        <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-java</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hjug.refactorfirst.testresources</groupId>
-            <artifactId>test-resources</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <type>jar</type>
-            <version>1.7.2</version>
-        </dependency>
-
-    </dependencies>
-
-    
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.hjug.refactorfirst</groupId>
+    <artifactId>refactor-first</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+  </parent>
+  <groupId>org.hjug.refactorfirst.effortranker</groupId>
+  <artifactId>effort-ranker</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.testresources</groupId>
+      <artifactId>test-resources</artifactId>
+      <version>0.3.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.2</version>
+      <type>jar</type>
+    </dependency>
+  </dependencies>
 </project>

--- a/graph-data-generator/pom.xml
+++ b/graph-data-generator/pom.xml
@@ -1,22 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>org.hjug.refactorfirst</groupId>
-        <artifactId>refactor-first</artifactId>
-        <version>0.3.1-SNAPSHOT</version>
-    </parent>
-
-    <groupId>org.hjug.refactorfirst.graphdatagenerator</groupId>
-    <artifactId>graph-data-generator</artifactId>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.hjug.refactorfirst.costbenefitcalculator</groupId>
-            <artifactId>cost-benefit-calculator</artifactId>
-            <version>0.3.1-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
-
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.hjug.refactorfirst</groupId>
+    <artifactId>refactor-first</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+  </parent>
+  <groupId>org.hjug.refactorfirst.graphdatagenerator</groupId>
+  <artifactId>graph-data-generator</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.costbenefitcalculator</groupId>
+      <artifactId>cost-benefit-calculator</artifactId>
+      <version>0.3.1-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,499 +1,475 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
-    <groupId>org.hjug.refactorfirst</groupId>
-    <artifactId>refactor-first</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
-    <packaging>pom</packaging>
-
-    <url>https://github.com/jimbethancourt/RefactorFirst</url>
-
-    <name>RefactorFirst</name>
-    <description>
-        Plugin that identifies God classes in a codebase and suggests which classes should be refactored first.
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.hjug.refactorfirst</groupId>
+  <artifactId>refactor-first</artifactId>
+  <version>0.3.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>RefactorFirst</name>
+  <description>Plugin that identifies God classes in a codebase and suggests which classes should be refactored first.
         Generates a graph and a table providing (hopefully) easy to understand guidance.
-        Can be used via command line, as a build plugin, or as a report plugin.
-    </description>
-
-    <licenses>
-        <license>
-            <name>Apache License 2.0</name>
-            <url> http://www.apache.org/licenses/</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <name>Jim Bethancourt</name>
-            <email>jimbethancourt@gmail.com</email>
-            <organization>Houston Java Users Group</organization>
-            <organizationUrl>http://www.hjug.org</organizationUrl>
-            <roles>
-                <role>developer</role>
-            </roles>
-            <timezone>CST</timezone>
-        </developer>
-    </developers>
-
-    <scm>
-        <connection>scm:git:https://github.com/jimbethancourt/RefactorFirst</connection>
-        <developerConnection>scm:git:https://github.com/jimbethancourt/RefactorFirst</developerConnection>
-        <url>https://github.com/jimbethancourt/RefactorFirst</url>
-      <tag>HEAD</tag>
+        Can be used via command line, as a build plugin, or as a report plugin.</description>
+  <url>https://github.com/jimbethancourt/RefactorFirst</url>
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>http://www.apache.org/licenses/</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <name>Jim Bethancourt</name>
+      <email>jimbethancourt@gmail.com</email>
+      <organization>Houston Java Users Group</organization>
+      <organizationUrl>http://www.hjug.org</organizationUrl>
+      <roles>
+        <role>developer</role>
+      </roles>
+      <timezone>CST</timezone>
+    </developer>
+  </developers>
+  <modules>
+    <module>test-resources</module>
+    <module>change-proneness-ranker</module>
+    <module>effort-ranker</module>
+    <module>cost-benefit-calculator</module>
+    <module>graph-data-generator</module>
+    <module>refactor-first-maven-plugin</module>
+    <!--<module>refactor-first-gradle-plugin</module>-->
+    <module>coverage</module>
+  </modules>
+  <scm>
+    <connection>scm:git:https://github.com/jimbethancourt/RefactorFirst</connection>
+    <developerConnection>scm:git:https://github.com/jimbethancourt/RefactorFirst</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/jimbethancourt/RefactorFirst</url>
   </scm>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/jimbethancourt/RefactorFirst/issues</url>
-    </issueManagement>
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-
-        <!--For errorprone on Java 8 -->
-        <javac.version>9+181-r4173-1</javac.version>
-
-        <!--Compiler plugins-->
-        <errorprone.version>2.5.1</errorprone.version>
-        <lombok.version>1.18.12</lombok.version>
-
-        <spotbugs.maven.plugin.version>4.0.0</spotbugs.maven.plugin.version>
-        <spotbugs.version>4.0.3</spotbugs.version>
-        <findsecbugs.plugin.version>1.10.1</findsecbugs.plugin.version>
-
-
-
-        <sonar.projectKey>jimbethancourt_RefactorFirst</sonar.projectKey>
-        <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
-        <sonar.organization>jimbethancourt-github</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-
-        <maven.core.version>3.8.2</maven.core.version>
-    </properties>
-
-    <modules>
-        <module>test-resources</module>
-        <module>change-proneness-ranker</module>
-        <module>effort-ranker</module>
-        <module>cost-benefit-calculator</module>
-        <module>graph-data-generator</module>
-        <module>refactor-first-maven-plugin</module>
-        <!--<module>refactor-first-gradle-plugin</module>-->
-        <module>coverage</module>
-    </modules>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.hjug.refactorfirst.changepronenessranker</groupId>
-                <artifactId>change-proneness-ranker</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hjug.refactorfirst.effortranker</groupId>
-                <artifactId>effort-ranker</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hjug.refactorfirst.costbenefitcalculator</groupId>
-                <artifactId>cost-benefit-calculator</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hjug.refactorfirst.graphdatagenerator</groupId>
-                <artifactId>graph-data-generator</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hjug.refactorfirst.plugin</groupId>
-                <artifactId>refactor-first-maven-plugin</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hjug.refactorfirst.testresources</groupId>
-                <artifactId>test-resources</artifactId>
-                <version>${project.version}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.jgit</groupId>
-                <artifactId>org.eclipse.jgit</artifactId>
-                <version>5.10.0.202012080955-r</version>
-                <scope>compile</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>net.sourceforge.pmd</groupId>
-                <artifactId>pmd-java</artifactId>
-                <version>6.46.0</version>
-                <scope>compile</scope>
-
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.beust</groupId>
-                        <artifactId>jcommander</artifactId>
-                    </exclusion>
-                    <!--
-                    Done to accommodate unknown license issue specified in
-                    https://github.com/jimbethancourt/RefactorFirst/issues/2
-                    -->
-                    <exclusion>
-                        <groupId>net.sourceforge.saxon</groupId>
-                        <artifactId>saxon</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.13.2.2</version>
-            </dependency>
-            <!--
-            <dependency>
-              <groupId>com.github.mauricioaniche</groupId>
-              <artifactId>ck</artifactId>
-              <version>0.6.2</version>
-            </dependency>
-            -->
-        </dependencies>
-    </dependencyManagement>
-
-
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/jimbethancourt/RefactorFirst/issues</url>
+  </issueManagement>
+  <properties>
+    <!--Compiler plugins-->
+    <errorprone.version>2.5.1</errorprone.version>
+    <findsecbugs.plugin.version>1.10.1</findsecbugs.plugin.version>
+    <!--For errorprone on Java 8 -->
+    <javac.version>9+181-r4173-1</javac.version>
+    <lombok.version>1.18.12</lombok.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.core.version>3.8.2</maven.core.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
+    <sonar.organization>jimbethancourt-github</sonar.organization>
+    <sonar.projectKey>jimbethancourt_RefactorFirst</sonar.projectKey>
+    <spotbugs.maven.plugin.version>4.0.0</spotbugs.maven.plugin.version>
+    <spotbugs.version>4.0.3</spotbugs.version>
+  </properties>
+  <dependencyManagement>
     <dependencies>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.4.4</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <optional>true</optional>
-        </dependency>
-
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.13.2.2</version>
+      </dependency>
+      <dependency>
+        <groupId>net.sourceforge.pmd</groupId>
+        <artifactId>pmd-java</artifactId>
+        <version>6.46.0</version>
+        <scope>compile</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+          </exclusion>
+          <!--
+                  Done to accommodate unknown license issue specified in
+                  https://github.com/jimbethancourt/RefactorFirst/issues/2
+                  -->
+          <exclusion>
+            <groupId>net.sourceforge.saxon</groupId>
+            <artifactId>saxon</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jgit</groupId>
+        <artifactId>org.eclipse.jgit</artifactId>
+        <version>5.10.0.202012080955-r</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hjug.refactorfirst.changepronenessranker</groupId>
+        <artifactId>change-proneness-ranker</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hjug.refactorfirst.costbenefitcalculator</groupId>
+        <artifactId>cost-benefit-calculator</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hjug.refactorfirst.effortranker</groupId>
+        <artifactId>effort-ranker</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hjug.refactorfirst.graphdatagenerator</groupId>
+        <artifactId>graph-data-generator</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hjug.refactorfirst.plugin</groupId>
+        <artifactId>refactor-first-maven-plugin</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hjug.refactorfirst.testresources</groupId>
+        <artifactId>test-resources</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <!--
+          <dependency>
+            <groupId>com.github.mauricioaniche</groupId>
+            <artifactId>ck</artifactId>
+            <version>0.6.2</version>
+          </dependency>
+          -->
     </dependencies>
-
-    <build>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.9.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.9.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.4.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <!--TODO: Add the SNYK plugin-->
+      <!-- https://github.com/snyk/snyk-maven-plugin -->
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.22.1</version>
+        <configuration>
+          <formats>
+            <!-- you can define as many formats as you want, each is independent -->
+            <format>
+              <!-- define the files to apply to -->
+              <includes>
+                <include>*.java</include>
+              </includes>
+              <!-- define the steps to apply to those files -->
+              <trimTrailingWhitespace/>
+              <endWithNewline/>
+              <indent>
+                <tabs>true</tabs>
+                <spacesPerTab>4</spacesPerTab>
+              </indent>
+            </format>
+          </formats>
+          <java>
+            <palantirJavaFormat/>
+          </java>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>apply</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.ekryd.sortpom</groupId>
+        <artifactId>sortpom-maven-plugin</artifactId>
+        <version>3.2.1</version>
+        <configuration>
+          <lineSeparator>\n</lineSeparator>
+          <encoding>${project.build.sourceEncoding}</encoding>
+          <sortExecutions>true</sortExecutions>
+          <sortProperties>true</sortProperties>
+          <sortModules>false</sortModules>
+          <sortPlugins>groupId,artifactId</sortPlugins>
+          <sortDependencies>groupId,artifactId</sortDependencies>
+          <keepBlankLines>false</keepBlankLines>
+          <expandEmptyElements>false</expandEmptyElements>
+          <spaceBeforeCloseEmptyElement>false</spaceBeforeCloseEmptyElement>
+          <createBackupFile>false</createBackupFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>project</id>
+            <goals>
+              <goal>sort</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Security checks -->
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${spotbugs.maven.plugin.version}</version>
+        <configuration>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+          <failOnError>true</failOnError>
+          <!--<includeFilterFile>${session.executionRootDirectory}/spotbugs-security-include.xml</includeFilterFile>
+                  <excludeFilterFile>${session.executionRootDirectory}/spotbugs-security-exclude.xml</excludeFilterFile>-->
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>${findsecbugs.plugin.version}</version>
+            </plugin>
+          </plugins>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>${spotbugs.version}</version>
+          </dependency>
+        </dependencies>
+        <!-- Uncomment the executions declaration below
+            to fail the build when violations are found-->
+        <!--
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>check</goal>
+                    </goals>
+                </execution>
+            </executions>
+            -->
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+          <compilerArgs>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+            <pathe>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${errorprone.version}</version>
+            </pathe>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.0.0</version>
+      </plugin>
+      <!-- From https://mkyong.com/maven/mvn-site-java-lang-classnotfoundexception-org-apache-maven-doxia-siterenderer-documentcontent/-->
+      <!--Needed to allow mvn site to work-->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.7.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.6</version>
+        <executions>
+          <!-- to avoid bugs in some situations -->
+          <execution>
+            <id>default-prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>csvreport</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+          <!-- create report during maven verify phase -->
+          <execution>
+            <id>report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>6.1.0</version>
+        <configuration>
+          <failBuildOnCVSS>8.0</failBuildOnCVSS>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
+  <profiles>
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                    <compilerArgs>
-                        <arg>-XDcompilePolicy=simple</arg>
-                        <arg>-Xplugin:ErrorProne</arg>
-                    </compilerArgs>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                            <version>${lombok.version}</version>
-                        </path>
-                        <pathe>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>${errorprone.version}</version>
-                        </pathe>
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.6</version>
-                <executions>
-                    <!-- to avoid bugs in some situations -->
-                    <execution>
-                        <id>default-prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-
-                    <!-- create report during maven verify phase -->
-                    <execution>
-                        <id>report</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-
-                    <execution>
-                        <id>csvreport</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- From https://mkyong.com/maven/mvn-site-java-lang-classnotfoundexception-org-apache-maven-doxia-siterenderer-documentcontent/-->
-            <!--Needed to allow mvn site to work-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.7.1</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.0.0</version>
-            </plugin>
-
-            <!-- Security checks -->
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>${spotbugs.maven.plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.github.spotbugs</groupId>
-                        <artifactId>spotbugs</artifactId>
-                        <version>${spotbugs.version}</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <effort>Max</effort>
-                    <threshold>Low</threshold>
-                    <failOnError>true</failOnError>
-                    <!--<includeFilterFile>${session.executionRootDirectory}/spotbugs-security-include.xml</includeFilterFile>
-                    <excludeFilterFile>${session.executionRootDirectory}/spotbugs-security-exclude.xml</excludeFilterFile>-->
-                    <plugins>
-                        <plugin>
-                            <groupId>com.h3xstream.findsecbugs</groupId>
-                            <artifactId>findsecbugs-plugin</artifactId>
-                            <version>${findsecbugs.plugin.version}</version>
-                        </plugin>
-                    </plugins>
-                </configuration>
-                <!-- Uncomment the executions declaration below
-                to fail the build when violations are found-->
-                <!--
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                -->
-            </plugin>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>6.1.0</version>
-                <configuration>
-                    <failBuildOnCVSS>8.0</failBuildOnCVSS>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <!--TODO: Add the SNYK plugin-->
-            <!-- https://github.com/snyk/snyk-maven-plugin -->
-
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.22.1</version>
-                <configuration>
-                    <formats>
-                        <!-- you can define as many formats as you want, each is independent -->
-                        <format>
-                            <!-- define the files to apply to -->
-                            <includes>
-                                <include>*.java</include>
-                            </includes>
-                            <!-- define the steps to apply to those files -->
-                            <trimTrailingWhitespace/>
-                            <endWithNewline/>
-                            <indent>
-                                <tabs>true</tabs>
-                                <spacesPerTab>4</spacesPerTab>
-                            </indent>
-                        </format>
-                    </formats>
-                    <java>
-                        <palantirJavaFormat/>
-                    </java>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>apply</goal>
-                        </goals>
-                        <phase>initialize</phase>
-                    </execution>
-                </executions>
-            </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="append">
+                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
         </plugins>
-    </build>
-
-
-    <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
-    <profiles>
-        <profile>
-            <id>jdk8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <fork>true</fork>
-                            <compilerArgs combine.children="append">
-                                <arg>
-                                    -J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar
-                                </arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>snapshot-release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-release-plugin</artifactId>
-                        <version>2.5.3</version>
-                        <configuration>
-                            <stagingRepository>https://oss.sonatype.org/content/repositories/snapshots/</stagingRepository>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-            </distributionManagement>
-        </profile>
-        <profile>
-            <id>publish</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>3.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.0</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <!--See http://maven.apache.org/plugins/maven-gpg-plugin/usage.html-->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <configuration>
-                                    <!-- Prevent 'gpg' from using pinentry programs -->
-                                    <gpgArguments>
-                                        <arg>--pinentry-mode</arg>
-                                        <arg>loopback</arg>
-                                    </gpgArguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-            <distributionManagement>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-            </distributionManagement>
-        </profile>
-    </profiles>
-
-
-
-
+      </build>
+    </profile>
+    <profile>
+      <id>snapshot-release</id>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+      </distributionManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>2.5.3</version>
+            <configuration>
+              <stagingRepository>https://oss.sonatype.org/content/repositories/snapshots/</stagingRepository>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>publish</id>
+      <distributionManagement>
+        <repository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+      </distributionManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <!--See http://maven.apache.org/plugins/maven-gpg-plugin/usage.html-->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <phase>verify</phase>
+                <configuration>
+                  <!-- Prevent 'gpg' from using pinentry programs -->
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.8</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/refactor-first-maven-plugin/pom.xml
+++ b/refactor-first-maven-plugin/pom.xml
@@ -1,70 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>org.hjug.refactorfirst</groupId>
-        <artifactId>refactor-first</artifactId>
-        <version>0.3.1-SNAPSHOT</version>
-    </parent>
-
-    <groupId>org.hjug.refactorfirst.plugin</groupId>
-    <artifactId>refactor-first-maven-plugin</artifactId>
-    <packaging>maven-plugin</packaging>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.hjug.refactorfirst.graphdatagenerator</groupId>
-            <artifactId>graph-data-generator</artifactId>
-        </dependency>
-
-        <!-- Maven Reporting -->
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>${maven.core.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.1</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <goalPrefix>refactor-first</goalPrefix>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default-descriptor</id>
-                        <phase>process-classes</phase>
-                    </execution>
-                    <execution>
-                        <id>generated-helpmojo</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-    
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.hjug.refactorfirst</groupId>
+    <artifactId>refactor-first</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+  </parent>
+  <groupId>org.hjug.refactorfirst.plugin</groupId>
+  <artifactId>refactor-first-maven-plugin</artifactId>
+  <packaging>maven-plugin</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <!-- Maven Reporting -->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.6.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hjug.refactorfirst.graphdatagenerator</groupId>
+      <artifactId>graph-data-generator</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <goalPrefix>refactor-first</goalPrefix>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generated-helpmojo</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-descriptor</id>
+            <phase>process-classes</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/test-resources/pom.xml
+++ b/test-resources/pom.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>org.hjug.refactorfirst</groupId>
-        <artifactId>refactor-first</artifactId>
-        <version>0.3.1-SNAPSHOT</version>
-    </parent>
-
-    <groupId>org.hjug.refactorfirst.testresources</groupId>
-    <artifactId>test-resources</artifactId>
-
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.hjug.refactorfirst</groupId>
+    <artifactId>refactor-first</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+  </parent>
+  <groupId>org.hjug.refactorfirst.testresources</groupId>
+  <artifactId>test-resources</artifactId>
 </project>


### PR DESCRIPTION
hi there!
I added a plugin execution to run in the validation phase of each module in the project.
The plugin sorts the pom.xml files inplace.
https://github.com/Ekryd/sortpom

I notice you've got a few security plugins, and maybe you're concerned and don't have the patience for validating a large change like this. In that case you could simply copy the plugin into your parent pom and run `mvn validate`. The committed changes should match exactly.

I'd like to make further PRs on the back of this foundation. Are you open to making JDK11 your base version? It would simplify the errorprone configuration for one.